### PR TITLE
CLN - gameOver 함수 함수명 및 인자명 변경

### DIFF
--- a/테트리스_완성-점수처리.c
+++ b/테트리스_완성-점수처리.c
@@ -459,9 +459,9 @@ void Check_line(void)
 	}
 }
 
-int gameOver(int rotation)
+int Game_over(int block)
 {
-	if (detect(rotation, 0, 0))
+	if (detect(block, 0, 0))
 		return 5; //∞‘¿” ≥°
 	else
 		return 0;
@@ -504,7 +504,7 @@ void moveBlock(void)
 			getchar();
 			exit(1);
 		}
-		if (gameOver(n))
+		if (Game_over(n))
 			break;
 
 


### PR DESCRIPTION
- 변경한 이유
gameOver 함수명은 함수인지 분별하기 어렵다고 판단함.
rotation 인자명은 블록 모양을 저장하는 역할의 의미를 포함하고 있지 않음.

- 변경 사항
gameOver에서 Game_over으로 변경함.
rotation에서 block으로 변경함.