### PR TITLE
CLN - main 함수 불필요한 코드 삭제

### DIFF
--- a/테트리스_완성-점수처리.c
+++ b/테트리스_완성-점수처리.c
@@ -605,13 +605,8 @@ void Run(void)
 int main()
 {
 	removeCursor(); //커서 깜박이 제거
-
-	setCursor(2, 1); //보드표시 시작위치 설정
 	showBoard(); //보드 출력
 	scoreLevel();
-
 	Run(); //보드 출력 움직임
-
 	getchar();
-
 }


### PR DESCRIPTION
- 변경한 이유
showBoard 함수에 이미 보드를 출력하는 시작 위치가 지정되어 있음.
하지만 기존 코드에서는 setCursor(2, 1) 코드를 통해 중복 지정하여 불필요한 코드라고 판단됨.

- 변경 사항
위의 코드를 삭제함.