### PR TITLE
CLN - moveblock 형식 일관성 유지

### DIFF
--- a/테트리스_완성-점수처리.c
+++ b/테트리스_완성-점수처리.c
@@ -486,11 +486,9 @@ void Run(void)
 
 	srand(time(NULL));
 
-
 	/*게임 시작~끝*/
 	while (1)
 	{
-
 		initial(CBLOCK_X, CBLOCK_Y); //블록 생성 위치 좌표 
 
 		block = (rand() % RAND) * 4;//난수생성
@@ -507,8 +505,12 @@ void Run(void)
 			exit(1);
 		}
 		if (Game_over(block))
-			break;
-
+		{
+			setCursor(35, 20);
+			printf("GAME OVER");
+			getchar();
+			exit(1);
+		}
 
 		/*블록 한개 위~밑 이동*/
 		while (1)
@@ -517,7 +519,6 @@ void Run(void)
 			int block_rotation = 0;
 
 			/*블록 아래로 이동*/
-
 			while (!_kbhit())
 			{
 				//블록 쇼
@@ -536,7 +537,9 @@ void Run(void)
 			}
 			/*detect함수에서 배열값 1발견시 중지*/
 			if (last_line == 1)
+			{
 				break;
+			}
 
 			key = _getch();
 			/*방향키*/
@@ -551,7 +554,6 @@ void Run(void)
 				showBlock(block);
 				break;
 			case UP:
-
 				// 첫수를구한다.
 				block_rotation = block / 4;
 				block_rotation *= 4;
@@ -573,7 +575,7 @@ void Run(void)
 				break;
 			case DOWN:
 				removeBlock(block, 0, 2);
-				//showBlock(n);
+				showBlock(block);
 				break;
 			case SPACE:
 				while (1)
@@ -585,22 +587,11 @@ void Run(void)
 						boardConginition(block, 0, 0);
 						break;
 					}
-
 				}
-
-
 			}
-
 		}
-
 	}
-
-	setCursor(35, 20);
-	printf("GAME OVER");
 }
-
-
-
 
 int main()
 {


### PR DESCRIPTION
- 변경한 이유
기존 switch 문은 case마다 removeblock, showblock 함수를 순서대로 호출하는 형식임.
하지만 DOWN에서 showblock 함수를 호출하지 않아서 일관성을 유지하지 않음.
또한 Game_win과 Game_over은 비슷한 기능을 가진 함수이지만 서로 다른 형식임.

- 변경 사항
DOWN에서 showblock 함수를 호출함.
Game_over 형식을 Game_win 형식으로 바꿈.