### PR TITLE
CLN - Game_over 함수 형식 일관성 유지

### DIFF
--- a/테트리스_완성-점수처리.c
+++ b/테트리스_완성-점수처리.c
@@ -464,9 +464,13 @@ void Check_line(void)
 int Game_over(int block)
 {
 	if (detect(block, 0, 0))
+	{
 		return 5; //∞‘¿” ≥°
+	}
 	else
+	{
 		return 0;
+	}
 }
 
 int Game_win(void)


### PR DESCRIPTION
- 변경한 이유
기존에는 if, else문에 중괄호를 사용하지 않아서 일관성을 유지하지 않음.

- 변경 사항
if, else문에 중괄호를 사용함.