### PR TITLE
CLN - Game_win 함수 형식 일관성 유지

### DIFF
--- a/테트리스_완성-점수처리.c
+++ b/테트리스_완성-점수처리.c
@@ -476,9 +476,13 @@ int Game_over(int block)
 int Game_win(void)
 {
 	if (level == 10)
+	{
 		return 1; //°ÔÀÓ½Â
+	}
 	else
+	{
 		return 0;
+	}
 }
 
 void Run(void)


### PR DESCRIPTION
- 변경한 이유
기존에는 if, else문에 중괄호를 사용하지 않아서 일관성을 유지하지 않음.

- 변경 사항
if, else문에 중괄호를 사용함.